### PR TITLE
fix: keep OG preview tags on the noindex press kit

### DIFF
--- a/src/api/seo.js
+++ b/src/api/seo.js
@@ -35,6 +35,9 @@ export const SEO = {
     description: 'Internal press kit.',
     canonical: `${SITE_URL}/cutmylips`,
     lang: 'uk',
+    ogTitle: 'Cutmylips — DISANTREFACT',
+    ogDescription: 'Прес-кіт альбому DISANTREFACT від Cutmylips.',
+    ogImage: DISANTREFACT_OG_IMAGE,
     noindex: true,
   },
 };

--- a/src/components/Seo/Seo.jsx
+++ b/src/components/Seo/Seo.jsx
@@ -17,6 +17,7 @@ export const Seo = ({
 }) => {
   const resolvedOgTitle = ogTitle ?? title;
   const resolvedOgDescription = ogDescription ?? description;
+  const ogLocale = lang === 'uk' ? 'uk_UA' : 'en_US';
   const jsonLdBlocks = Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : [];
 
   return (
@@ -26,17 +27,17 @@ export const Seo = ({
       <meta name="description" content={description} />
       <link rel="canonical" href={canonical} />
       {noindex && <meta name="robots" content="noindex,nofollow" />}
-      {!noindex && <meta property="og:title" content={resolvedOgTitle} />}
-      {!noindex && <meta property="og:description" content={resolvedOgDescription} />}
-      {!noindex && <meta property="og:image" content={ogImage} />}
-      {!noindex && <meta property="og:type" content={ogType} />}
-      {!noindex && <meta property="og:url" content={canonical} />}
-      {!noindex && <meta property="og:site_name" content="belletriq" />}
-      {!noindex && <meta property="og:locale" content="en_US" />}
-      {!noindex && <meta name="twitter:card" content="summary_large_image" />}
-      {!noindex && <meta name="twitter:title" content={resolvedOgTitle} />}
-      {!noindex && <meta name="twitter:description" content={resolvedOgDescription} />}
-      {!noindex && <meta name="twitter:image" content={ogImage} />}
+      <meta property="og:title" content={resolvedOgTitle} />
+      <meta property="og:description" content={resolvedOgDescription} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:site_name" content="belletriq" />
+      <meta property="og:locale" content={ogLocale} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={resolvedOgTitle} />
+      <meta name="twitter:description" content={resolvedOgDescription} />
+      <meta name="twitter:image" content={ogImage} />
       {jsonLdBlocks.map((block, index) => (
         <script key={index} type="application/ld+json">
           {JSON.stringify(block)}

--- a/tests/prerender.test.js
+++ b/tests/prerender.test.js
@@ -118,9 +118,10 @@ describe('dist/cutmylips/index.html', () => {
     expect(cutmylips).toMatch(canonicalMatcher('https://belletriq.com/cutmylips'));
   });
 
-  it('suppresses OG tags on noindex (REV-002)', () => {
-    expect(cutmylips).not.toContain('og:image');
-    expect(cutmylips).not.toContain('property="og:');
+  it('still ships OG tags for link previews despite noindex (press kit is shared by direct link)', () => {
+    expect(cutmylips).toContain('property="og:title"');
+    expect(cutmylips).toContain('property="og:image"');
+    expect(cutmylips).toContain('content="https://belletriq.com/og-disantrefact.png"');
   });
 });
 


### PR DESCRIPTION
After #27 deployed, /cutmylips shared in Telegram showed no preview. Root cause: OG tags were suppressed on noindex routes (REV-002), but noindex (keep out of Google) and OG (link preview in messengers) are independent concerns — the EPK press kit is shared by direct link, so it needs a preview even though it must stay out of search. This decouples them: OG/Twitter tags now render regardless of noindex; the robots noindex meta stays. cutmylips gets og:title/og:description/og:image (album card) + og:locale derived from lang (uk_UA); home/disantrefact unchanged. Test updated to assert cutmylips ships OG AND still carries noindex. lint + 20 tests green. NB: /disantrefact OG is correct on prod (verified via curl) — its missing Telegram preview is Telegram's link cache, not code; refresh via @WebpageBot.