### PR TITLE
feat: reframe home copy for b2b sound-for-brands positioning

### DIFF
--- a/src/pages/AboutPage/AboutPage.jsx
+++ b/src/pages/AboutPage/AboutPage.jsx
@@ -7,11 +7,18 @@ export const AboutPage = () => {
       <div className={styles.content}>
         <CubeText />
 
-        <p className={styles.description}>
-          We are the Ukrainian creative community which unites likeminded people
-          and promotes cultural development in it’s own way. Mostly focused on
-          sound, but featured in a vast variety of art forms.
-        </p>
+        <div className={styles.description}>
+          <h1 className={styles.headline}>SONIC VISION</h1>
+          <p className={styles.tagline}>Sound for brands.</p>
+          <p className={styles.lead}>
+            Audio post-production, mixing, sound design, and bespoke music.
+          </p>
+          <p className={styles.note}>
+            Beyond commissioned work, belletriq functions as a music label and
+            creative platform — releasing forward-thinking electronic music from
+            Ukraine and Eastern Europe and developing cultural projects.
+          </p>
+        </div>
       </div>
 
       <div className={styles.line}></div>

--- a/src/pages/AboutPage/AboutPage.module.scss
+++ b/src/pages/AboutPage/AboutPage.module.scss
@@ -48,13 +48,43 @@
   @include font-orditron-400;
   max-width: 450px;
   font-size: 18px;
-  height: 100%;
 
   pointer-events: none;
+
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 
   @include bp-mobile {
     font-size: 18px;
   }
+}
+
+.headline {
+  @include font-orditron-700;
+  font-size: 26px;
+  letter-spacing: 2px;
+  line-height: 1.1;
+
+  @include bp-mobile {
+    font-size: 22px;
+  }
+}
+
+.tagline {
+  @include font-orditron-500;
+  font-size: 20px;
+}
+
+.lead {
+  @include font-orditron-400;
+  line-height: 1.4;
+}
+
+.note {
+  @include font-orditron-400;
+  font-size: 16px;
+  line-height: 1.45;
 }
 
 .line {

--- a/src/pages/MusicPage/MusicPage.jsx
+++ b/src/pages/MusicPage/MusicPage.jsx
@@ -9,6 +9,10 @@ export const MusicPage = () => {
       <div className={styles.content}>
         <h2 className={styles.title}>DISCOGRAPHY</h2>
 
+        <p className={styles.subtitle}>
+          New, forward-thinking electronic music from Ukraine and Eastern Europe.
+        </p>
+
         <div className={styles.animation_container}>
           <img
             src={playerAnimation}

--- a/src/pages/MusicPage/MusicPage.module.scss
+++ b/src/pages/MusicPage/MusicPage.module.scss
@@ -93,7 +93,7 @@
 
 .title {
   @extend %title;
-  margin-bottom: 25px;
+  margin-bottom: 8px;
 
   @include bp-tablet {
     text-align: center;
@@ -106,6 +106,26 @@
   @include bp-mobile-small {
     margin-top: 15px;
     margin-bottom: 10px;
+  }
+}
+
+.subtitle {
+  @include font-orditron-400;
+  font-size: 16px;
+  margin-bottom: 22px;
+
+  @include bp-tablet {
+    text-align: center;
+  }
+
+  @include bp-mobile {
+    font-size: 14px;
+    margin-bottom: 18px;
+    text-align: start;
+  }
+
+  @include bp-mobile-small {
+    margin-bottom: 12px;
   }
 }
 

--- a/src/pages/ServicesPage/ServicesPage.jsx
+++ b/src/pages/ServicesPage/ServicesPage.jsx
@@ -62,8 +62,8 @@ export const ServicesPage = () => {
 
           <article className={styles.description_box}>
             <p className={styles.description}>
-              We deliver high-quality, end-to-end audio solutions, including music production, mixing, mastering, scoring and SFX. 
-              We also offer licensing and sync services, ensuring seamless sound integration into any creative project.
+              We craft bespoke music, sound design and SFX for commercial video production — full-cycle audio post-production, mixing and mastering for advertising, film and brands.
+              Clients include Adidas, Coca-Cola, Pepsi, BMW, Puma and Sony Music, with licensing and sync for seamless integration into any project.
             </p>
 
             <button className={styles.link} onClick={handleFormOpen} aria-label="contact us">


### PR DESCRIPTION
## Summary

- Reframe the home copy from "Ukrainian creative community / label" to the B2B **sound for brands** positioning from the owner's deck — copy only, the design and layout are untouched.
- Surface the keyword clusters we want to rank for (bespoke music; sound design & SFX for commercial video production; forward-thinking electronic music from Ukraine & Eastern Europe) as real, prerendered on-page text.

## Motivation

Track B, PR1 of 3. The live site reads as a label/artist community, which is a positioning gap vs. the actual goal — winning bespoke-music and SFX/sound-design work for advertising. This PR fixes the home copy; the indexable per-service pages (the real ranking layer) come in PR2.

Owner constraint for the home: «переписати копірайт, не перемальовувати» — rewrite the copy, don't redesign. So this is strictly a copy change.

## Changes

- **UI — Hero (AboutPage):** swapped the "creative community" paragraph for the owner-approved SONIC VISION block. It introduces the page's single `<h1>` (SONIC VISION), a "Sound for brands." tagline, the keyword-bearing services line (audio post-production, mixing, sound design, bespoke music), and a music-label note. The spinning `belletriq` cube and the layout are unchanged.
- **UI — Services description:** rewrote the panel paragraph to lead with "sound design & SFX for commercial video production" and added a light client-brand mention (Adidas, Coca-Cola, Pepsi, BMW, Puma, Sony Music). The video slider / logo wall is not touched.
- **UI — Music (DISCOGRAPHY):** added a one-line subtitle — "New, forward-thinking electronic music from Ukraine and Eastern Europe" — to carry the label/discovery cluster.
- **Styling:** minimal, copy-fit only (heading/tagline sizes in the hero; a `.subtitle` rule + title spacing in Music).
- **Tests:** none added — the existing prerender suite already asserts the home title, canonical, JSON-LD, indexability and real content, and still passes unchanged.

Deliberately **not** changed: the Services slider (`api/thumbnails.js`, `Slider`, `VideoModal`), `SEO.home.title`, and the home meta description (already at the optimal SERP length — the new angles live in body copy, where they actually help ranking, so the optional meta tweak was skipped).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 20/20 (prerender suite green)
- [x] `npm run build` — green
- [x] Prerendered `dist/index.html` verified: exactly **one** `<h1>` (SONIC VISION) + three `<h2>`; all new copy present; old "creative community" copy gone; title + meta description unchanged
- [x] Visual check on the production `vite preview` (not dev) at **1440 / 1200 / 390** — hero, Services and Music: layout identical to master, only the text differs; no console/page errors

## Rollout

- **Feature flag:** none
- **Migration:** none
- **Backwards compatibility:** ✅ static content change

## Rollback

Revert this commit — it only touches three page components and their SCSS.

## Risks & open questions

- The EE-music keyword clusters now render as real text, but ranking for head terms is content + time, not guaranteed from copy alone — the indexable per-service pages in PR2 are the actual ranking layer.
- Nothing else on the home changed; slider, menus, background and SEO tags are identical to master.

## Screenshots / recordings

Verified locally against the production preview at desktop (1440), tablet (1200) and mobile (390); before/after were identical in layout with only the text changed. See the test plan.
