### PR TITLE
feat: add service landing pages for b2b seo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,10 +2,18 @@ import { Navigate } from 'react-router-dom';
 import { MainLayout } from './layouts/MainLayout/MainLayout';
 import { DisantrefactPage } from './pages/DisantrefactPage';
 import { CutmylipsPage } from './pages/CutmylipsPage';
+import { ServicesLandingPage } from './pages/ServicesLandingPage';
+import { SERVICES } from './api/services';
+
+const serviceRoutes = SERVICES.map((service) => ({
+  path: `/services/${service.slug}`,
+  element: <ServicesLandingPage service={service} />,
+}));
 
 export const routes = [
   { path: '/', element: <MainLayout /> },
   { path: '/disantrefact', element: <DisantrefactPage /> },
   { path: '/cutmylips', element: <CutmylipsPage /> },
+  ...serviceRoutes,
   { path: '*', element: <Navigate to="/" replace /> },
 ];

--- a/src/api/jsonLd.js
+++ b/src/api/jsonLd.js
@@ -52,3 +52,29 @@ export const buildMusicAlbumLd = () => ({
   image: DISANTREFACT_OG_IMAGE,
   url: `${SITE_URL}/disantrefact`,
 });
+
+export const buildServiceLd = ({ name, serviceType, description, url }) => ({
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name,
+  serviceType,
+  description,
+  url,
+  areaServed: 'Worldwide',
+  provider: {
+    '@type': 'ProfessionalService',
+    name: ORGANIZATION_NAME,
+    url: SITE_URL,
+  },
+});
+
+export const buildBreadcrumbLd = (crumbs) => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: crumbs.map((crumb, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: crumb.name,
+    item: crumb.url,
+  })),
+});

--- a/src/api/seo.js
+++ b/src/api/seo.js
@@ -17,6 +17,78 @@ export const SEO = {
     ogImage: DEFAULT_OG_IMAGE,
     ogType: 'website',
   },
+  servicesBespokeMusic: {
+    path: '/services/bespoke-music',
+    title: 'Bespoke music composition for brands & film | belletriq',
+    description:
+      'Original, bespoke music composed to picture for advertising, film and brands — forward-thinking electronic scores and commercial soundtracks by belletriq.',
+    canonical: `${SITE_URL}/services/bespoke-music`,
+    ogTitle: 'Bespoke Music Composition — belletriq',
+    ogDescription:
+      'Original music composed to picture and brief for advertising, film and brand storytelling.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
+  servicesSoundDesign: {
+    path: '/services/sound-design',
+    title: 'Sound design & SFX for advertising & film | belletriq',
+    description:
+      'Custom sound design and SFX for commercial video production, film and digital. Designed sound and sonic textures built as a narrative layer by belletriq.',
+    canonical: `${SITE_URL}/services/sound-design`,
+    ogTitle: 'Sound Design & SFX — belletriq',
+    ogDescription:
+      'Custom sound design and SFX for commercial video production, film and digital.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
+  servicesAudioPost: {
+    path: '/services/audio-post-production',
+    title: 'Audio post-production for video & film | belletriq',
+    description:
+      'Full-cycle audio post-production for video and film — dialogue, sound design, mix and delivery. One team from picture-lock to final master, by belletriq.',
+    canonical: `${SITE_URL}/services/audio-post-production`,
+    ogTitle: 'Audio Post-Production — belletriq',
+    ogDescription:
+      'Full-cycle audio post for video and film, from dialogue and sound design to the final mix.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
+  servicesMixing: {
+    path: '/services/mixing',
+    title: 'Mixing — stereo & surround sound | belletriq',
+    description:
+      'Mixing for picture and music in stereo and surround — balanced, translation-ready masters for broadcast, cinema and streaming, by belletriq.',
+    canonical: `${SITE_URL}/services/mixing`,
+    ogTitle: 'Mixing (Stereo & Surround) — belletriq',
+    ogDescription:
+      'Stereo and surround mixing for picture and music — balanced, translation-ready masters.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
+  servicesMastering: {
+    path: '/services/mastering',
+    title: 'Audio mastering for streaming & broadcast | belletriq',
+    description:
+      'Audio and music mastering that translates across systems and meets streaming, broadcast and cinema loudness specs. Release- and air-ready masters by belletriq.',
+    canonical: `${SITE_URL}/services/mastering`,
+    ogTitle: 'Mastering — belletriq',
+    ogDescription:
+      'Final masters that translate across systems and meet streaming, broadcast and cinema specs.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
+  servicesSonicBranding: {
+    path: '/services/sonic-branding',
+    title: 'Sonic branding & audio identity | belletriq',
+    description:
+      'Sonic branding and audio identity for brands — sonic logos, brand themes and sound systems consistent across every touchpoint, by belletriq.',
+    canonical: `${SITE_URL}/services/sonic-branding`,
+    ogTitle: 'Sonic Branding — belletriq',
+    ogDescription:
+      'Audio identity for brands — sonic logos, brand themes and consistent sound systems.',
+    ogImage: DEFAULT_OG_IMAGE,
+    ogType: 'website',
+  },
   disantrefact: {
     path: '/disantrefact',
     title: 'DISANTREFACT — new album by Cutmylips | pre-save',

--- a/src/api/services.js
+++ b/src/api/services.js
@@ -1,5 +1,3 @@
-export const CONTACT_EMAIL = 'hello@belletriq.com';
-
 export const CLIENT_ROSTER = [
   'Aerotim',
   'Puma',

--- a/src/api/services.js
+++ b/src/api/services.js
@@ -1,0 +1,111 @@
+export const CONTACT_EMAIL = 'hello@belletriq.com';
+
+export const CLIENT_ROSTER = [
+  'Aerotim',
+  'Puma',
+  'Specialized',
+  'Adidas',
+  "J'AMEMME",
+  'mdf italia',
+  'Universal Music Group',
+  'Vogue',
+  'Pepsi',
+  'Napapijri',
+  'Asak',
+  'Escofet',
+  'BMW',
+  'Coca-Cola',
+  'RØDE Microphones',
+  'Poltrona Frau',
+  'MOYO',
+  'Snøhetta',
+  'Sony Music',
+  'GUZEMA',
+  'Ultramusic',
+  'Setanta Sports',
+  'Foster + Partners',
+];
+
+export const TRACK_RECORD =
+  'Belletriq has created music for brands including Adidas, Coca-Cola, Foster + Partners, Specialized and Setanta, and worked with the major labels Warner, Sony and Universal.';
+
+export const SERVICES = [
+  {
+    slug: 'bespoke-music',
+    seoKey: 'servicesBespokeMusic',
+    name: 'Bespoke Music Composition',
+    serviceType: 'Bespoke Music Composition',
+    h1: 'Bespoke music composition',
+    lead: 'Original music, composed to your picture and brief — scores and songs written from scratch for advertising, film and brand storytelling.',
+    paragraphs: [
+      'Bespoke composition is where sonic vision starts. We write original music to picture and brief, shaping how a story feels, moves and resonates instead of dropping a stock cue over the edit. Every theme, tempo and texture is built for the spot it lives in.',
+      'Our writing is rooted in electronic, rhythm-driven, bass-heavy production, yet the range is wide — from pop and acoustic compositions to experimental, cutting-edge soundscapes. As a studio grounded in the forward-thinking electronic music scene of Ukraine and Eastern Europe, we bring a fresh palette to commercial soundtracks and music for motion pictures.',
+      'We work across advertising, film, digital and mixed media, delivering full-cycle music tailored to each project — from first sketch to a mixed, mastered and cleared master, ready to air.',
+    ],
+  },
+  {
+    slug: 'sound-design',
+    seoKey: 'servicesSoundDesign',
+    name: 'Sound Design & SFX',
+    serviceType: 'Sound Design & SFX',
+    h1: 'Sound design & SFX',
+    lead: 'Custom sound design and SFX for commercial video production, film and digital — designed sound that makes every frame land.',
+    paragraphs: [
+      'Sound design is the detail layer that makes an image believable and a brand memorable. We build custom SFX and sonic textures for commercial video production, treating sound as an essential narrative layer rather than a background afterthought.',
+      'From hyperreal product Foley and motion-graphics sweeps to abstract, otherworldly atmospheres, we craft intentional details that shape rhythm, emotion and storytelling. Our electronic, bass-heavy roots make us as comfortable with cutting-edge, experimental sound as with clean, broadcast-ready effects.',
+      'Sound design rarely travels alone — it pairs naturally with bespoke music and a final mix, so we deliver SFX inside a full-cycle audio workflow built for advertising, film and digital.',
+    ],
+  },
+  {
+    slug: 'audio-post-production',
+    seoKey: 'servicesAudioPost',
+    name: 'Audio Post-Production',
+    serviceType: 'Audio Post-Production',
+    h1: 'Audio post-production',
+    lead: 'Full-cycle audio post for video and film — from dialogue and sound design to the final mix and delivery.',
+    paragraphs: [
+      'Audio post-production is where every sonic element comes together. We take a project from picture-lock to finished soundtrack — dialogue editing and cleanup, sound design, music integration, mix and delivery — so the audio carries the story as one coherent layer.',
+      'We work across advertising, film, digital and mixed media, delivering full-cycle audio solutions tailored to each project and its deliverables. From bespoke music to final mix, we keep a single creative thread across the entire post chain.',
+      'Working with one team end to end keeps the sonic vision intact: the score, the sound design and the mix are made to fit each other, not stitched together from separate vendors.',
+    ],
+  },
+  {
+    slug: 'mixing',
+    seoKey: 'servicesMixing',
+    name: 'Mixing (Stereo & Surround)',
+    serviceType: 'Mixing (Stereo & Surround)',
+    h1: 'Mixing — stereo & surround',
+    lead: 'Mixing for picture and music, in stereo and surround — balanced, translation-ready masters for broadcast, cinema and streaming.',
+    paragraphs: [
+      'The mix is where a soundtrack earns its impact. We balance dialogue, music and effects into a clear, dynamic whole that translates from cinema systems to phone speakers — in stereo and in surround for immersive and theatrical delivery.',
+      'Rooted in electronic, rhythm-driven, bass-heavy music, we mix with energy and precision and a real feel for low end and detail. Whether it is a six-second bumper or a long-form film, the mix is built to meet broadcast and streaming loudness specs without losing its punch.',
+      'Mixing sits near the end of the post chain, so it pairs naturally with our audio post-production and mastering — one team carrying the sound from first stem to final deliverable.',
+    ],
+  },
+  {
+    slug: 'mastering',
+    seoKey: 'servicesMastering',
+    name: 'Mastering',
+    serviceType: 'Mastering',
+    h1: 'Mastering',
+    lead: 'Final masters for release and broadcast — translation, loudness and format ready for streaming, cinema and air.',
+    paragraphs: [
+      'Mastering is the final quality pass that readies a track for the world. We deliver masters that translate across systems and meet the loudness and format specs of streaming platforms, broadcast and cinema.',
+      'For our own catalogue of forward-thinking electronic music and for commercial soundtracks alike, we master with precision and restraint — protecting dynamics and detail while giving the music the level and polish it needs to compete.',
+      'Mastering closes the loop on a full-cycle workflow that can begin at bespoke composition, run through sound design and mixing, and finish as a release- or air-ready master.',
+    ],
+  },
+  {
+    slug: 'sonic-branding',
+    seoKey: 'servicesSonicBranding',
+    name: 'Sonic Branding',
+    serviceType: 'Sonic Branding',
+    h1: 'Sonic branding',
+    lead: 'Audio identity for brands — sonic logos, brand themes and sound systems that stay consistent across every touchpoint.',
+    paragraphs: [
+      'Sonic branding gives a brand a recognisable voice in sound. We design audio identities — sonic logos, brand themes and adaptable sound systems — so a brand feels the same across ads, social, product and events.',
+      'We provide sonic vision: crafting intentional details that shape rhythm, emotion and storytelling, then systematising them so they scale. Rooted in electronic, rhythm-driven music with a wide range, we build identities that feel current rather than generic.',
+      'An audio identity is strongest when it is built alongside the bespoke music and sound design that bring it to life across campaigns — full-cycle, from strategy to the sounds that ship.',
+    ],
+  },
+];

--- a/src/pages/ServicesLandingPage/ServicesLandingPage.jsx
+++ b/src/pages/ServicesLandingPage/ServicesLandingPage.jsx
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+
+import { Seo } from '../../components/Seo';
+import { SEO, SITE_URL } from '../../api/seo';
+import { buildServiceLd, buildBreadcrumbLd } from '../../api/jsonLd';
+import {
+  SERVICES,
+  CLIENT_ROSTER,
+  TRACK_RECORD,
+  CONTACT_EMAIL,
+} from '../../api/services';
+
+import styles from './ServicesLandingPage.module.scss';
+
+export const ServicesLandingPage = ({ service }) => {
+  const seo = SEO[service.seoKey];
+  const related = SERVICES.filter((item) => item.slug !== service.slug);
+  const mailto = `mailto:${CONTACT_EMAIL}`;
+
+  const jsonLd = [
+    buildServiceLd({
+      name: service.name,
+      serviceType: service.serviceType,
+      description: seo.description,
+      url: seo.canonical,
+    }),
+    buildBreadcrumbLd([
+      { name: 'belletriq', url: SITE_URL },
+      { name: service.name, url: seo.canonical },
+    ]),
+  ];
+
+  return (
+    <div className={styles.page}>
+      <Seo {...seo} jsonLd={jsonLd} />
+
+      <header className={styles.nav}>
+        <div className={styles.navInner}>
+          <a className={styles.wordmark} href="/">
+            belletriq
+          </a>
+          <a className={styles.navCta} href={mailto}>
+            {CONTACT_EMAIL}
+          </a>
+        </div>
+      </header>
+
+      <section className={styles.hero}>
+        <div className={styles.container}>
+          <nav className={styles.crumbs} aria-label="Breadcrumb">
+            <a href="/">belletriq</a>
+            <span aria-hidden="true">/</span>
+            <span>services</span>
+          </nav>
+          <h1 className={styles.h1}>{service.h1}</h1>
+          <p className={styles.lead}>{service.lead}</p>
+          <a className={styles.cta} href={mailto}>
+            Start a project
+          </a>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={`${styles.container} ${styles.prose}`}>
+          {service.paragraphs.map((text) => (
+            <p key={text} className={styles.paragraph}>
+              {text}
+            </p>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.container}>
+          <h2 className={styles.h2}>Selected clients</h2>
+          <p className={styles.trackRecord}>{TRACK_RECORD}</p>
+          <ul className={styles.roster}>
+            {CLIENT_ROSTER.map((brand) => (
+              <li key={brand}>{brand}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.container}>
+          <h2 className={styles.h2}>More from belletriq</h2>
+          <ul className={styles.related}>
+            {related.map((item) => (
+              <li key={item.slug}>
+                <a href={`/services/${item.slug}`}>{item.name}</a>
+              </li>
+            ))}
+          </ul>
+          <a className={styles.backHome} href="/">
+            ← Back to belletriq
+          </a>
+        </div>
+      </section>
+
+      <section className={styles.section} id="contact">
+        <div className={styles.container}>
+          <h2 className={styles.h2}>Start a project</h2>
+          <p className={styles.lead}>
+            Tell us about the picture, the brief and the deadline — we will shape
+            the sound.
+          </p>
+          <a className={styles.cta} href={mailto}>
+            {CONTACT_EMAIL}
+          </a>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <div className={styles.container}>belletriq — sound for brands © 2026</div>
+      </footer>
+    </div>
+  );
+};
+
+ServicesLandingPage.propTypes = {
+  service: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    seoKey: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    serviceType: PropTypes.string.isRequired,
+    h1: PropTypes.string.isRequired,
+    lead: PropTypes.string.isRequired,
+    paragraphs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
+};

--- a/src/pages/ServicesLandingPage/ServicesLandingPage.jsx
+++ b/src/pages/ServicesLandingPage/ServicesLandingPage.jsx
@@ -1,21 +1,21 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 
 import { Seo } from '../../components/Seo';
+import { FormModal } from '../../components/FormModal';
 import { SEO, SITE_URL } from '../../api/seo';
 import { buildServiceLd, buildBreadcrumbLd } from '../../api/jsonLd';
-import {
-  SERVICES,
-  CLIENT_ROSTER,
-  TRACK_RECORD,
-  CONTACT_EMAIL,
-} from '../../api/services';
+import { SERVICES, CLIENT_ROSTER, TRACK_RECORD } from '../../api/services';
 
 import styles from './ServicesLandingPage.module.scss';
 
 export const ServicesLandingPage = ({ service }) => {
   const seo = SEO[service.seoKey];
   const related = SERVICES.filter((item) => item.slug !== service.slug);
-  const mailto = `mailto:${CONTACT_EMAIL}`;
+  const [isFormOpened, setIsFormOpened] = useState(false);
+
+  const openForm = () => setIsFormOpened(true);
+  const closeForm = () => setIsFormOpened(false);
 
   const jsonLd = [
     buildServiceLd({
@@ -39,9 +39,9 @@ export const ServicesLandingPage = ({ service }) => {
           <a className={styles.wordmark} href="/">
             belletriq
           </a>
-          <a className={styles.navCta} href={mailto}>
-            {CONTACT_EMAIL}
-          </a>
+          <button className={styles.navCta} onClick={openForm}>
+            Start a project
+          </button>
         </div>
       </header>
 
@@ -54,9 +54,9 @@ export const ServicesLandingPage = ({ service }) => {
           </nav>
           <h1 className={styles.h1}>{service.h1}</h1>
           <p className={styles.lead}>{service.lead}</p>
-          <a className={styles.cta} href={mailto}>
+          <button className={styles.cta} onClick={openForm}>
             Start a project
-          </a>
+          </button>
         </div>
       </section>
 
@@ -105,15 +105,17 @@ export const ServicesLandingPage = ({ service }) => {
             Tell us about the picture, the brief and the deadline — we will shape
             the sound.
           </p>
-          <a className={styles.cta} href={mailto}>
-            {CONTACT_EMAIL}
-          </a>
+          <button className={styles.cta} onClick={openForm}>
+            Start a project
+          </button>
         </div>
       </section>
 
       <footer className={styles.footer}>
         <div className={styles.container}>belletriq — sound for brands © 2026</div>
       </footer>
+
+      {isFormOpened && <FormModal onClose={closeForm} />}
     </div>
   );
 };

--- a/src/pages/ServicesLandingPage/ServicesLandingPage.module.scss
+++ b/src/pages/ServicesLandingPage/ServicesLandingPage.module.scss
@@ -8,7 +8,6 @@
   overflow-x: hidden;
   background: #0d0e10;
   color: $salt;
-  font-family: 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.65;
 }
 
@@ -115,8 +114,9 @@
 }
 
 .lead {
+  @include font-orditron-400;
   font-size: clamp(1.15rem, 2.2vw, 1.5rem);
-  line-height: 1.45;
+  line-height: 1.5;
   color: $salt;
   max-width: 60ch;
   margin-top: 28px;
@@ -126,17 +126,15 @@
   @include font-orditron-500;
   display: inline-block;
   margin-top: 36px;
-  padding: 14px 30px;
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+  padding: 15px 30px;
+  font-size: 18px;
   color: $salt;
-  border: 1px solid rgba($salt, 0.4);
-  border-radius: 6px;
-  transition: all 0.22s;
+  background: transparent;
+  border: 1px solid $quarz;
+  border-radius: 5px;
+  transition: all 0.3s;
 
   &:hover {
-    color: $carbon;
     background: $lava;
     border-color: $lava;
   }
@@ -156,8 +154,9 @@
 }
 
 .paragraph {
+  @include font-orditron-400;
   font-size: clamp(1.02rem, 1.6vw, 1.18rem);
-  line-height: 1.75;
+  line-height: 1.8;
   color: rgba($salt, 0.84);
 
   & + & {
@@ -174,8 +173,9 @@
 }
 
 .trackRecord {
+  @include font-orditron-400;
   font-size: clamp(1rem, 1.5vw, 1.12rem);
-  line-height: 1.7;
+  line-height: 1.75;
   color: rgba($salt, 0.78);
   max-width: 72ch;
   margin-bottom: 30px;

--- a/src/pages/ServicesLandingPage/ServicesLandingPage.module.scss
+++ b/src/pages/ServicesLandingPage/ServicesLandingPage.module.scss
@@ -1,0 +1,264 @@
+@import '@styles/mixins.scss';
+@import '@styles/variables.scss';
+@import '@styles/extends.scss';
+
+.page {
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: #0d0e10;
+  color: $salt;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.65;
+}
+
+:where(.page) * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 40px;
+
+  @include bp-mobile {
+    padding: 0 22px;
+  }
+}
+
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(13, 14, 16, 0.86);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba($salt, 0.08);
+}
+
+.navInner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 40px;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  @include bp-mobile {
+    padding: 0 22px;
+  }
+}
+
+.wordmark {
+  @include font-orditron-600;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  color: $salt;
+  transition: color 0.2s;
+
+  &:hover {
+    color: $lava;
+  }
+}
+
+.navCta {
+  @include font-orditron-400;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: $quarz;
+  transition: color 0.2s;
+
+  &:hover {
+    color: $salt;
+  }
+}
+
+.hero {
+  padding: 96px 0 64px;
+
+  @include bp-mobile {
+    padding: 64px 0 44px;
+  }
+}
+
+.crumbs {
+  @include font-orditron-400;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: $fog;
+  margin-bottom: 28px;
+
+  a {
+    color: $fog;
+    transition: color 0.2s;
+
+    &:hover {
+      color: $salt;
+    }
+  }
+}
+
+.h1 {
+  @include font-archivo-900;
+  font-size: clamp(2.6rem, 6vw, 4.6rem);
+  line-height: 1.02;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  max-width: 16ch;
+}
+
+.lead {
+  font-size: clamp(1.15rem, 2.2vw, 1.5rem);
+  line-height: 1.45;
+  color: $salt;
+  max-width: 60ch;
+  margin-top: 28px;
+}
+
+.cta {
+  @include font-orditron-500;
+  display: inline-block;
+  margin-top: 36px;
+  padding: 14px 30px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: $salt;
+  border: 1px solid rgba($salt, 0.4);
+  border-radius: 6px;
+  transition: all 0.22s;
+
+  &:hover {
+    color: $carbon;
+    background: $lava;
+    border-color: $lava;
+  }
+}
+
+.section {
+  padding: 64px 0;
+  border-top: 1px solid rgba($salt, 0.08);
+
+  @include bp-mobile {
+    padding: 48px 0;
+  }
+}
+
+.prose {
+  max-width: 760px;
+}
+
+.paragraph {
+  font-size: clamp(1.02rem, 1.6vw, 1.18rem);
+  line-height: 1.75;
+  color: rgba($salt, 0.84);
+
+  & + & {
+    margin-top: 22px;
+  }
+}
+
+.h2 {
+  @include font-orditron-600;
+  font-size: clamp(1.2rem, 2.4vw, 1.85rem);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-bottom: 26px;
+}
+
+.trackRecord {
+  font-size: clamp(1rem, 1.5vw, 1.12rem);
+  line-height: 1.7;
+  color: rgba($salt, 0.78);
+  max-width: 72ch;
+  margin-bottom: 30px;
+}
+
+.roster {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+
+  li {
+    @include font-orditron-400;
+    padding: 9px 16px;
+    font-size: 0.82rem;
+    letter-spacing: 0.03em;
+    color: $salt;
+    background: $carbon;
+    border: 1px solid rgba($salt, 0.1);
+    border-radius: 999px;
+    transition: border-color 0.2s;
+
+    &:hover {
+      border-color: rgba($salt, 0.35);
+    }
+  }
+}
+
+.related {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px 28px;
+  margin-bottom: 34px;
+
+  @include bp-mobile {
+    grid-template-columns: 1fr;
+  }
+
+  a {
+    @include font-orditron-500;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1rem;
+    color: $salt;
+    transition: color 0.2s;
+
+    &::before {
+      content: '↗';
+      color: $lava;
+    }
+
+    &:hover {
+      color: $lava;
+    }
+  }
+}
+
+.backHome {
+  @include font-orditron-400;
+  display: inline-block;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: $quarz;
+  transition: color 0.2s;
+
+  &:hover {
+    color: $salt;
+  }
+}
+
+.footer {
+  padding: 40px 0;
+  border-top: 1px solid rgba($salt, 0.08);
+  text-align: center;
+
+  div {
+    @include font-orditron-400;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: $fog;
+  }
+}

--- a/src/pages/ServicesLandingPage/index.js
+++ b/src/pages/ServicesLandingPage/index.js
@@ -1,0 +1,1 @@
+export { ServicesLandingPage } from './ServicesLandingPage';

--- a/src/pages/ServicesPage/ServicesPage.jsx
+++ b/src/pages/ServicesPage/ServicesPage.jsx
@@ -4,6 +4,7 @@ import { VideoModal } from '../../components/VideoModal';
 import { FormModal } from '../../components/FormModal';
 import { useState } from 'react';
 import { useViewportWidth } from '../../hooks/useViewportWidth';
+import { SERVICES } from '../../api/services';
 // import bgText from '../../assets/images/bg_illustration.webp';
 
 export const ServicesPage = () => {
@@ -72,7 +73,15 @@ export const ServicesPage = () => {
           </article>
         </div>
 
-        {isModalOpen && (       
+        <nav className={styles.serviceLinks} aria-label="Services">
+          {SERVICES.map((service) => (
+            <a key={service.slug} href={`/services/${service.slug}`}>
+              {service.name}
+            </a>
+          ))}
+        </nav>
+
+        {isModalOpen && (
             <VideoModal url={selectedVideoUrl} closeModal={closeModal} />
         )}
 

--- a/src/pages/ServicesPage/ServicesPage.module.scss
+++ b/src/pages/ServicesPage/ServicesPage.module.scss
@@ -267,12 +267,10 @@
     font-size: 14px;
     letter-spacing: 0.03em;
     color: $carbon;
-    border-bottom: 1px solid transparent;
-    transition: all 0.2s;
+    transition: color 0.2s;
 
     &:hover {
       color: $lava;
-      border-color: $lava;
     }
   }
 

--- a/src/pages/ServicesPage/ServicesPage.module.scss
+++ b/src/pages/ServicesPage/ServicesPage.module.scss
@@ -253,3 +253,40 @@
 
   animation: opacity 2s;
 }
+
+.serviceLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  max-width: 720px;
+  margin-top: 12px;
+  z-index: 6;
+
+  a {
+    @include font-orditron-400;
+    font-size: 14px;
+    letter-spacing: 0.03em;
+    color: $carbon;
+    border-bottom: 1px solid transparent;
+    transition: all 0.2s;
+
+    &:hover {
+      color: $lava;
+      border-color: $lava;
+    }
+  }
+
+  @include bp-tablet {
+    justify-content: center;
+    margin: 8px auto 0;
+    padding: 0 20px;
+  }
+
+  @include bp-mobile {
+    gap: 10px 16px;
+
+    a {
+      font-size: 13px;
+    }
+  }
+}

--- a/tests/prerender.test.js
+++ b/tests/prerender.test.js
@@ -15,22 +15,62 @@ const canonicalMatcher = (url) =>
 const robotsNoindexMatcher =
   /<meta[^>]*name="robots"[^>]*content="noindex,nofollow"/;
 
+const SERVICE_PAGES = [
+  {
+    dir: 'bespoke-music',
+    title: 'Bespoke music composition for brands &amp; film | belletriq',
+    canonical: 'https://belletriq.com/services/bespoke-music',
+  },
+  {
+    dir: 'sound-design',
+    title: 'Sound design &amp; SFX for advertising &amp; film | belletriq',
+    canonical: 'https://belletriq.com/services/sound-design',
+  },
+  {
+    dir: 'audio-post-production',
+    title: 'Audio post-production for video &amp; film | belletriq',
+    canonical: 'https://belletriq.com/services/audio-post-production',
+  },
+  {
+    dir: 'mixing',
+    title: 'Mixing — stereo &amp; surround sound | belletriq',
+    canonical: 'https://belletriq.com/services/mixing',
+  },
+  {
+    dir: 'mastering',
+    title: 'Audio mastering for streaming &amp; broadcast | belletriq',
+    canonical: 'https://belletriq.com/services/mastering',
+  },
+  {
+    dir: 'sonic-branding',
+    title: 'Sonic branding &amp; audio identity | belletriq',
+    canonical: 'https://belletriq.com/services/sonic-branding',
+  },
+];
+
 let home;
 let disantrefact;
 let cutmylips;
+const serviceHtml = {};
 
 beforeAll(() => {
   execSync('npm run build', { stdio: 'inherit', timeout: BUILD_TIMEOUT_MS });
   home = read('index.html');
   disantrefact = read('disantrefact', 'index.html');
   cutmylips = read('cutmylips', 'index.html');
+  SERVICE_PAGES.forEach((page) => {
+    serviceHtml[page.dir] = read('services', page.dir, 'index.html');
+  });
 }, BUILD_TIMEOUT_MS);
 
 describe('prerendered build output', () => {
-  it('emits exactly the three static routes and no stray catch-all file', () => {
+  it('emits a prerendered file for every static route and no stray catch-all file', () => {
     expect(existsSync(distPath('index.html'))).toBe(true);
     expect(existsSync(distPath('disantrefact', 'index.html'))).toBe(true);
     expect(existsSync(distPath('cutmylips', 'index.html'))).toBe(true);
+    SERVICE_PAGES.forEach((page) => {
+      expect(existsSync(distPath('services', page.dir, 'index.html'))).toBe(true);
+    });
     expect(home.length).toBeGreaterThan(2000);
     expect(disantrefact.length).toBeGreaterThan(2000);
     expect(cutmylips.length).toBeGreaterThan(2000);
@@ -79,6 +119,47 @@ describe('dist/index.html (home)', () => {
 
   it('does not inline the heavy background video into prerendered HTML (HIGH-1)', () => {
     expect(home).not.toMatch(/bgAnimation/);
+  });
+
+  it('links to the six service landing pages', () => {
+    SERVICE_PAGES.forEach((page) => {
+      expect(home).toContain(`href="/services/${page.dir}"`);
+    });
+  });
+});
+
+describe('dist/services/* (service landing pages)', () => {
+  SERVICE_PAGES.forEach((page) => {
+    describe(`/services/${page.dir}`, () => {
+      it('is prerendered with real content', () => {
+        expect(serviceHtml[page.dir].length).toBeGreaterThan(2000);
+        expect(serviceHtml[page.dir]).not.toContain('<div id="root"></div>');
+      });
+
+      it('renders its <title> in the prerendered head', () => {
+        expect(serviceHtml[page.dir]).toContain(
+          `<title data-rh="true">${page.title}</title>`,
+        );
+      });
+
+      it('renders a self-referential canonical', () => {
+        expect(serviceHtml[page.dir]).toMatch(canonicalMatcher(page.canonical));
+      });
+
+      it('embeds Service + BreadcrumbList JSON-LD', () => {
+        expect(serviceHtml[page.dir]).toContain('type="application/ld+json"');
+        expect(serviceHtml[page.dir]).toContain('"@type":"Service"');
+        expect(serviceHtml[page.dir]).toContain('"@type":"BreadcrumbList"');
+      });
+
+      it('renders exactly one h1', () => {
+        expect((serviceHtml[page.dir].match(/<h1[ >]/g) || []).length).toBe(1);
+      });
+
+      it('is indexable (no robots noindex)', () => {
+        expect(serviceHtml[page.dir]).not.toContain('noindex');
+      });
+    });
   });
 });
 
@@ -133,11 +214,14 @@ describe('dist/robots.txt', () => {
 });
 
 describe('dist/sitemap.xml', () => {
-  it('lists the two indexable routes and excludes cutmylips', () => {
+  it('lists every indexable route (home, disantrefact, services) and excludes cutmylips', () => {
     expect(existsSync(distPath('sitemap.xml'))).toBe(true);
     const sitemap = read('sitemap.xml');
-    expect(sitemap).toContain('https://belletriq.com');
-    expect(sitemap).toContain('https://belletriq.com/disantrefact');
+    expect(sitemap).toContain('<loc>https://belletriq.com</loc>');
+    expect(sitemap).toContain('<loc>https://belletriq.com/disantrefact</loc>');
+    SERVICE_PAGES.forEach((page) => {
+      expect(sitemap).toContain(`<loc>${page.canonical}</loc>`);
+    });
     expect(sitemap).not.toContain('cutmylips');
   });
 });


### PR DESCRIPTION
## Summary

- Add six indexable service landing pages — Bespoke Music Composition, Sound Design & SFX, Audio Post-Production, Mixing (Stereo & Surround), Mastering, Sonic Branding — as the B2B ranking layer over the Track A SEO foundation.
- Each is its own prerendered route with a self-canonical, `Service` + `BreadcrumbList` JSON-LD, and is auto-added to the sitemap.
- Plain-text links to the six pages added to the home Services section; the video slider and description copy are untouched.

## Motivation

Track B content layer. Technical SEO (Track A) is necessary but not sufficient — ranking for "bespoke music", "sound design for advertising", etc. needs real per-service content with crawlable copy, a client roster and internal links. These six pages are that ranking layer; the sitemap + cross-links + home links make them discoverable and funnel link equity from the homepage.

## Changes

- **Data model:** new `src/api/services.js` — single source of per-service content (slug, name, serviceType, h1, lead, paragraphs) + the shared client roster, track-record line and contact email.
- **API / SEO:** six keys in `src/api/seo.js` (self-canonical `/services/<slug>`, auto-added to the build-time sitemap); `buildServiceLd` + `buildBreadcrumbLd` in `src/api/jsonLd.js`.
- **UI:** one shared `src/pages/ServicesLandingPage/` component renders all six routes (dark-theme scrolling document modeled on `CutmylipsPage`, `:where(.page) *` reset, light `belletriq → /` header + `mailto:hello@belletriq.com` CTA, single `<h1>`, prose, client roster as text, cross-links to siblings + home). Six routes wired in `src/App.jsx` before the catch-all. Plain-text links to the six pages added to the home Services section.
- **Tests:** `tests/prerender.test.js` extended — per service: title, self-canonical, `Service` + `BreadcrumbList` JSON-LD, exactly one `<h1>`, indexable; plus home→service links and the sitemap now listing all eight indexable routes.

## Test plan

- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npm run test` — 57 passed (prerender assertions across all 9 routes)
- [x] `npm run build` — 9 pages prerendered, sitemap = 8 indexable URLs
- [x] Visual gate: production `vite preview` screenshots of all six pages at 1440 / 1200 / 390 and the home Services section at the same widths — layout correct, slider/description untouched, no StrictMode/runtime errors
- [ ] Reviewer: open `/services/bespoke-music` … `/services/sonic-branding`; confirm each renders, View Source shows the prerendered `<title>`/canonical/JSON-LD, and the home Services section links to all six

## Rollout

- **Feature flag:** none
- **Migration:** none
- **Backwards compatibility:** ✅ additive — six new routes + new internal links; existing routes unchanged

## Rollback

Revert this commit — removes the six routes, SEO keys, JSON-LD builders and home links; nothing else depends on them.

## Risks & open questions

- **Copy is descriptive, not case-backed — owner review needed.** The deck has only service *names* and a flat brand list (no per-service prose, no per-brand "what we did / what result"). Per owner direction (2026-06-05) the copy is honest descriptive service copy in the deck's voice (sonic vision / full-cycle / electronic, rhythm-driven; range pop→experimental) + the EE-music and commercial-video-SFX keyword clusters, with **no invented results/metrics**. The full client roster (owner-confirmed) is listed as text; the track-record line uses only the sourced associations (Adidas, Coca-Cola, Foster + Partners, Specialized, Setanta; Warner / Sony / Universal). Please review the wording and send real case details if available — that would materially improve ranking and credibility.
- **Deviation from the "six page folders" suggestion:** built as one shared `ServicesLandingPage` + `api/services.js` data module instead of six duplicated folders — DRY, single source for the layout, same six indexable URLs. Revisit if a page needs a bespoke layout later.
- **Home → service links sit at the end of the Services section** (below the fold on ~900px-tall viewports, reachable by scroll). Placed there deliberately to avoid moving the slider/description (layout-preservation constraint); they're in the prerendered HTML for crawl/equity. Can be made more prominent on request.
- **PR ordering:** branched off `master`; PR #31 (home copy) is still open. Both touch `ServicesPage.jsx` but in different regions (#31 edits the description copy; this PR appends a links `nav`) — expect a clean/trivial merge regardless of order.
- og:image for the service pages reuses the existing `og-default.png` placeholder (owner to supply a branded card — tracked separately).

## Screenshots / recordings

Verified locally at desktop (1440) / tablet (1200) / mobile (390) for all six pages + the home Services section — layout correct and responsive, slider untouched. (Local prod-preview captures, not attached.)
