### PR TITLE
Refine home hero typography & copy (review feedback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .env
 .feature-dev
 .DS_Store
+.vercel

--- a/src/pages/AboutPage/AboutPage.jsx
+++ b/src/pages/AboutPage/AboutPage.jsx
@@ -8,7 +8,7 @@ export const AboutPage = () => {
         <CubeText />
 
         <div className={styles.description}>
-          <h1 className={styles.headline}>SONIC VISION</h1>
+          <h1 className={styles.headline}>sonic vision</h1>
           <p className={styles.tagline}>Sound for brands.</p>
           <p className={styles.lead}>
             Audio post-production, mixing, sound design, and bespoke music.
@@ -16,7 +16,7 @@ export const AboutPage = () => {
           <p className={styles.note}>
             Beyond commissioned work, belletriq functions as a music label and
             creative platform — releasing forward-thinking electronic music from
-            Ukraine and Eastern Europe and developing cultural projects.
+            Ukraine and developing cultural projects.
           </p>
         </div>
       </div>

--- a/src/pages/AboutPage/AboutPage.module.scss
+++ b/src/pages/AboutPage/AboutPage.module.scss
@@ -64,6 +64,7 @@
   @include font-orditron-500;
   font-size: 26px;
   line-height: 1.1;
+  width: fit-content;
   transform: scaleX(1.58);
   transform-origin: left;
 

--- a/src/pages/AboutPage/AboutPage.module.scss
+++ b/src/pages/AboutPage/AboutPage.module.scss
@@ -61,10 +61,11 @@
 }
 
 .headline {
-  @include font-orditron-700;
+  @include font-orditron-500;
   font-size: 26px;
-  letter-spacing: 2px;
   line-height: 1.1;
+  transform: scaleX(1.58);
+  transform-origin: left;
 
   @include bp-mobile {
     font-size: 22px;
@@ -72,8 +73,7 @@
 }
 
 .tagline {
-  @include font-orditron-500;
-  font-size: 20px;
+  @include font-orditron-400;
 }
 
 .lead {

--- a/src/pages/MusicPage/MusicPage.jsx
+++ b/src/pages/MusicPage/MusicPage.jsx
@@ -10,7 +10,7 @@ export const MusicPage = () => {
         <h2 className={styles.title}>DISCOGRAPHY</h2>
 
         <p className={styles.subtitle}>
-          New, forward-thinking electronic music from Ukraine and Eastern Europe.
+          New, forward-thinking electronic music from Ukraine.
         </p>
 
         <div className={styles.animation_container}>


### PR DESCRIPTION
Addresses review feedback on the home page (`/`).

## Changes
- **Headline "sonic vision"** — lowercase + Orbitron 500 stretched horizontally (`scaleX(1.58)`, verified pixel-perfect against the approved reference). Was uppercase Orbitron 700.
- **Tagline "Sound for brands."** — demoted to body styling (Orbitron 400) so only the headline reads as a logotype.
- **"Eastern Europe"** — removed from the about note and the discography subtitle. Kept in the bespoke-composition service copy as an SEO keyword cluster.
- **chore** — add `.vercel` to `.gitignore`.

## Notes
- Headline at `scaleX(1.58)` fits down to ~320px (~227px in ~240px area); comfortable on 360px+.
- lint + tests green (57/57).