### PR TITLE
fix: relax desktop scroll-snap to proximity for service links

### DIFF
--- a/src/layouts/MainLayout/MainLayout.module.scss
+++ b/src/layouts/MainLayout/MainLayout.module.scss
@@ -21,7 +21,7 @@
 
   @include bp-desktop {
     padding-left: 300px;
-    scroll-snap-type: y mandatory;
+    scroll-snap-type: y proximity;
   }
 
   @include bp-tablet {


### PR DESCRIPTION
## Summary
- On desktop the service links at the bottom of the **Services** section were nearly impossible to reach: `scroll-snap-type: y mandatory` locked the viewport to each section's top, leaving the links below the fold with no way to hold them on screen — any scroll toward them snapped back. Switching to `proximity` lets users stop mid-section to reach the links while sections still snap softly when paged through.

## Changes
- `MainLayout.module.scss`: desktop `scroll-snap-type` `mandatory` → `proximity` (single declaration).

## Test plan
- `npm run lint` — clean.
- Manual (desktop ≥ 1367px): scroll to Services, confirm the service links can be held on screen and clicked; section snapping still feels intact.
- Tablet/mobile unaffected — snap is desktop-only (`bp-desktop`).

## Rollback
- `git revert <sha>` — single-line CSS change, no migrations or state.