### PR TITLE
feat: enrich disantrefact MusicAlbum schema for richer search results

### DIFF
--- a/src/api/disantrefact.js
+++ b/src/api/disantrefact.js
@@ -1,0 +1,48 @@
+export const STREAM_LINKS = [
+  {
+    label: 'Spotify',
+    icon: 'spotify',
+    href: 'https://open.spotify.com/album/48INkrzUDxeVtKj5fqn3Ub?si=_bpUuBZTTP-LIxEGLnCV2g',
+    isAlbumPage: true,
+  },
+  {
+    label: 'Apple Music',
+    icon: 'appleMusic',
+    href: 'https://music.apple.com/au/album/disantrefact/6768293725',
+    isAlbumPage: true,
+  },
+  {
+    label: 'YouTube Music',
+    icon: 'youtubeMusic',
+    href: 'https://music.youtube.com/playlist?list=OLAK5uy_lUHQkmJlijq2r-47lTh53s_Dg7uRW1BKA&si=VjiSa0-l41HHkjGa',
+    isAlbumPage: true,
+  },
+  {
+    label: 'Deezer',
+    icon: 'deezer',
+    href: 'https://link.deezer.com/s/33wa9nzAdSzJeVDSkWm41',
+    isAlbumPage: true,
+  },
+  {
+    label: 'Tidal',
+    icon: 'tidal',
+    href: 'https://tidal.com/album/523459824/u',
+    isAlbumPage: true,
+  },
+  {
+    label: 'Bandcamp',
+    icon: 'bandcamp',
+    href: 'https://cutmylips.bandcamp.com/album/disantrefact',
+    isAlbumPage: true,
+  },
+  {
+    label: 'YouTube',
+    icon: 'youtube',
+    href: 'https://youtu.be/Tm_GbJLUew4',
+    isAlbumPage: false,
+  },
+];
+
+export const ALBUM_STREAM_URLS = STREAM_LINKS.filter(
+  (link) => link.isAlbumPage,
+).map((link) => link.href);

--- a/src/api/disantrefact.js
+++ b/src/api/disantrefact.js
@@ -46,3 +46,32 @@ export const STREAM_LINKS = [
 export const ALBUM_STREAM_URLS = STREAM_LINKS.filter(
   (link) => link.isAlbumPage,
 ).map((link) => link.href);
+
+export const TRACK_NAMES = [
+  'Aaa',
+  'Palladium',
+  '062',
+  'Zymno',
+  'Olovo',
+  'Qusto',
+  'Gladiola',
+  'Oos Oom',
+  'Crashwreck',
+  'Love U Down',
+  'Xm2',
+  'Dream Club',
+  'Mind Race',
+  'Cry Mriy',
+  'Post Cry',
+  'Olfactorium',
+  'Kimberlite',
+  'Ikigai',
+  'Manifesting',
+  'Rechi 555',
+  'Haunt',
+  'Akou',
+  'Pink',
+  'Sophisticated',
+  'Nuke Rain',
+  'Pleochronic',
+];

--- a/src/api/jsonLd.js
+++ b/src/api/jsonLd.js
@@ -1,4 +1,4 @@
-import { ALBUM_STREAM_URLS } from './disantrefact';
+import { ALBUM_STREAM_URLS, TRACK_NAMES } from './disantrefact';
 import links from './links';
 import { SITE_URL, DISANTREFACT_OG_IMAGE } from './seo';
 
@@ -7,7 +7,7 @@ const SAME_AS_TITLES = ['instagram', 'linktree', 'youtube'];
 const ORGANIZATION_NAME = 'belletriq';
 const ALBUM_NAME = 'DISANTREFACT';
 const ALBUM_ARTIST = 'Cutmylips';
-const ALBUM_NUM_TRACKS = 25;
+const ALBUM_RELEASE_DATE = '2026-06-11';
 const ALBUM_GENRE = ['Futuristic pop', 'Indietronica', 'IDM'];
 const ALBUM_ARTIST_SAME_AS = [
   'https://open.spotify.com/artist/107LVbAcRXB1TBzqo6itz2',
@@ -55,11 +55,17 @@ export const buildMusicAlbumLd = () => ({
     name: ALBUM_ARTIST,
     sameAs: ALBUM_ARTIST_SAME_AS,
   },
-  numTracks: ALBUM_NUM_TRACKS,
+  datePublished: ALBUM_RELEASE_DATE,
   genre: ALBUM_GENRE,
+  numTracks: TRACK_NAMES.length,
   image: DISANTREFACT_OG_IMAGE,
   url: `${SITE_URL}/disantrefact`,
   sameAs: ALBUM_STREAM_URLS,
+  track: TRACK_NAMES.map((name, index) => ({
+    '@type': 'MusicRecording',
+    name,
+    position: index + 1,
+  })),
 });
 
 export const buildServiceLd = ({ name, serviceType, description, url }) => ({

--- a/src/api/jsonLd.js
+++ b/src/api/jsonLd.js
@@ -1,3 +1,4 @@
+import { ALBUM_STREAM_URLS } from './disantrefact';
 import links from './links';
 import { SITE_URL, DISANTREFACT_OG_IMAGE } from './seo';
 
@@ -7,6 +8,11 @@ const ORGANIZATION_NAME = 'belletriq';
 const ALBUM_NAME = 'DISANTREFACT';
 const ALBUM_ARTIST = 'Cutmylips';
 const ALBUM_NUM_TRACKS = 25;
+const ALBUM_GENRE = ['Futuristic pop', 'Indietronica', 'IDM'];
+const ALBUM_ARTIST_SAME_AS = [
+  'https://open.spotify.com/artist/107LVbAcRXB1TBzqo6itz2',
+  'https://soundcloud.com/cutmylips',
+];
 
 const getSameAs = () => {
   const resolved = SAME_AS_TITLES.map(
@@ -47,10 +53,13 @@ export const buildMusicAlbumLd = () => ({
   byArtist: {
     '@type': 'MusicGroup',
     name: ALBUM_ARTIST,
+    sameAs: ALBUM_ARTIST_SAME_AS,
   },
   numTracks: ALBUM_NUM_TRACKS,
+  genre: ALBUM_GENRE,
   image: DISANTREFACT_OG_IMAGE,
   url: `${SITE_URL}/disantrefact`,
+  sameAs: ALBUM_STREAM_URLS,
 });
 
 export const buildServiceLd = ({ name, serviceType, description, url }) => ({

--- a/src/pages/DisantrefactPage/data.js
+++ b/src/pages/DisantrefactPage/data.js
@@ -1,43 +1,5 @@
 export const YT_VIDEO_ID = 'Q2ihmC8a_RE';
 
-export const STREAM_LINKS = [
-  {
-    label: 'Spotify',
-    icon: 'spotify',
-    href: 'https://open.spotify.com/album/48INkrzUDxeVtKj5fqn3Ub?si=_bpUuBZTTP-LIxEGLnCV2g',
-  },
-  {
-    label: 'Apple Music',
-    icon: 'appleMusic',
-    href: 'https://music.apple.com/au/album/disantrefact/6768293725',
-  },
-  {
-    label: 'YouTube Music',
-    icon: 'youtubeMusic',
-    href: 'https://music.youtube.com/playlist?list=OLAK5uy_lUHQkmJlijq2r-47lTh53s_Dg7uRW1BKA&si=VjiSa0-l41HHkjGa',
-  },
-  {
-    label: 'Deezer',
-    icon: 'deezer',
-    href: 'https://link.deezer.com/s/33wa9nzAdSzJeVDSkWm41',
-  },
-  {
-    label: 'Tidal',
-    icon: 'tidal',
-    href: 'https://tidal.com/album/523459824/u',
-  },
-  {
-    label: 'Bandcamp',
-    icon: 'bandcamp',
-    href: 'https://cutmylips.bandcamp.com/album/disantrefact',
-  },
-  {
-    label: 'YouTube',
-    icon: 'youtube',
-    href: 'https://youtu.be/Tm_GbJLUew4',
-  },
-];
-
 export const SOCIAL_LINKS = [
   {
     label: 'Instagram',

--- a/src/pages/DisantrefactPage/molecules/StreamRail/index.jsx
+++ b/src/pages/DisantrefactPage/molecules/StreamRail/index.jsx
@@ -1,4 +1,4 @@
-import { STREAM_LINKS } from '../../data';
+import { STREAM_LINKS } from '../../../../api/disantrefact';
 import { Icon } from '../../icons';
 import styles from './index.module.scss';
 

--- a/tests/prerender.test.js
+++ b/tests/prerender.test.js
@@ -166,7 +166,7 @@ describe('dist/services/* (service landing pages)', () => {
 describe('dist/disantrefact/index.html', () => {
   it('renders the disantrefact title', () => {
     expect(disantrefact).toContain(
-      '<title data-rh="true">DISANTREFACT — new album by Cutmylips | pre-save</title>',
+      '<title data-rh="true">DISANTREFACT — new album by Cutmylips</title>',
     );
   });
 
@@ -181,8 +181,33 @@ describe('dist/disantrefact/index.html', () => {
     );
   });
 
-  it('embeds MusicAlbum JSON-LD', () => {
-    expect(disantrefact).toContain('"@type":"MusicAlbum"');
+  it('embeds MusicAlbum JSON-LD enriched with album sameAs, genre and artist profiles', () => {
+    const album = [
+      ...disantrefact.matchAll(
+        /<script[^>]*application\/ld\+json[^>]*>(.*?)<\/script>/g,
+      ),
+    ]
+      .map((match) => JSON.parse(match[1]))
+      .find((block) => block['@type'] === 'MusicAlbum');
+
+    expect(album).toBeDefined();
+    expect(album.genre).toEqual(['Futuristic pop', 'Indietronica', 'IDM']);
+    expect(album.byArtist.sameAs).toContain(
+      'https://open.spotify.com/artist/107LVbAcRXB1TBzqo6itz2',
+    );
+    expect(album.byArtist.sameAs).toContain('https://soundcloud.com/cutmylips');
+    expect(album.sameAs).toHaveLength(6);
+    expect(album.sameAs).toContain(
+      'https://cutmylips.bandcamp.com/album/disantrefact',
+    );
+    expect(album.sameAs).not.toContain('https://youtu.be/Tm_GbJLUew4');
+  });
+
+  it('still renders all seven streaming links in the StreamRail (youtu.be excluded only from schema)', () => {
+    expect(disantrefact).toContain('href="https://youtu.be/Tm_GbJLUew4"');
+    expect(disantrefact).toContain(
+      'href="https://cutmylips.bandcamp.com/album/disantrefact"',
+    );
   });
 
   it('is indexable (no robots noindex)', () => {

--- a/tests/prerender.test.js
+++ b/tests/prerender.test.js
@@ -201,6 +201,15 @@ describe('dist/disantrefact/index.html', () => {
       'https://cutmylips.bandcamp.com/album/disantrefact',
     );
     expect(album.sameAs).not.toContain('https://youtu.be/Tm_GbJLUew4');
+    expect(album.datePublished).toBe('2026-06-11');
+    expect(album.numTracks).toBe(26);
+    expect(album.track).toHaveLength(26);
+    expect(album.track[0]).toMatchObject({
+      '@type': 'MusicRecording',
+      name: 'Aaa',
+      position: 1,
+    });
+    expect(album.track[25]).toMatchObject({ name: 'Pleochronic', position: 26 });
   });
 
   it('still renders all seven streaming links in the StreamRail (youtu.be excluded only from schema)', () => {


### PR DESCRIPTION
## Summary

- Enrich the `/disantrefact` `MusicAlbum` JSON-LD so Google can resolve the page to the album entity and qualify it for richer results / knowledge-panel: `sameAs` (album streaming pages), `genre`, `byArtist.sameAs` (artist profiles), `datePublished`, and the full 26-track `track` listing.
- Move the album data source-of-truth into `src/api/disantrefact.js` so the JSON-LD builder and the page's StreamRail consume one list instead of duplicating it.

## Motivation

The page was already indexable with a minimal `MusicAlbum` block, but it carried no link between the page and the album's streaming presence, no genre, no release date, and no tracklist — the main on-page SEO lever left undercranked. `sameAs` is what ties this URL to the album as an entity; `track` opens track-level rich-result surface.

## Changes

- **Data model:** new `src/api/disantrefact.js` — `STREAM_LINKS` (each tagged `isAlbumPage`), derived `ALBUM_STREAM_URLS`, and `TRACK_NAMES` (26 titles in release order). Removed the duplicate `STREAM_LINKS` from `DisantrefactPage/data.js`.
- **API:** `buildMusicAlbumLd()` now emits `sameAs` (6 album-page URLs), `genre`, `byArtist.sameAs`, `datePublished` (2026-06-11), and `track` (26 × `MusicRecording` with `position`). `numTracks` is now derived from `TRACK_NAMES.length` so it can't drift from the tracklist.
- **UI:** `StreamRail` repointed to the api source. Still renders all 7 links — the bare `youtu.be` single-video link is excluded from schema `sameAs` only (it's a video, not the album), not from the UI.
- **Tests:** prerender assertions over the real `dist/disantrefact/index.html` for the full enriched JSON-LD (sameAs, genre, byArtist, datePublished, numTracks=26, track length + first/last entries, youtu.be exclusion). Also refreshed a stale title assertion — the album was cut over to released in `ef0f08c` and the copy dropped `| pre-save`, but the test wasn't updated, so the disantrefact prerender block was RED independent of this change.
- **Docs / config:** none.

## Test plan

- [x] `npm test` — 58 passed (vite-react-ssg build + prerender assertions on emitted HTML).
- [x] `npm run lint` — clean (`--max-warnings 0`).
- [ ] Post-deploy: paste `https://belletriq.com/disantrefact` into Google Rich Results Test and confirm the MusicAlbum block (with tracklist) validates.

## Rollout

- **Feature flag:** none.
- **Migration:** none.
- **Backwards compatibility:** ✅ — the only consumer of the moved `STREAM_LINKS` (StreamRail) was updated; `YT_VIDEO_ID` / `SOCIAL_LINKS` stay in `data.js`, untouched.

## Rollback

Revert this PR — the JSON-LD falls back to the prior minimal `MusicAlbum` block. No data or schema migration involved.

## Risks & open questions

- Tracklist + release date were sourced from the album's Spotify and Bandcamp pages and cross-checked (both agree: 26 tracks, identical order, release 2026-06-11). Track titles are stored clean (no `ft.` suffixes — featuring credits aren't part of the title).
- `?si` tracking params are left on the album `sameAs` URLs — harmless for `sameAs`. Stripping `&si` from the YouTube Music URL without dropping its `?list=` album id would need real URL parsing, which isn't worth it here.
